### PR TITLE
Find by name or sku

### DIFF
--- a/lib/qb_integration/services/item.rb
+++ b/lib/qb_integration/services/item.rb
@@ -5,8 +5,13 @@ module QBIntegration
         super("Item", config)
       end
 
-      def find_by_sku(sku, fields = "*")
+      def find_by_name(sku, fields = "*")
         response = quickbooks.query("select #{fields} from Item where Name = '#{sku}'")
+        response.entries.first
+      end
+
+      def find_by_sku(sku, fields = "*")
+        response = quickbooks.query("select #{fields} from Item where Sku = '#{sku}'")
         response.entries.first
       end
 
@@ -32,7 +37,7 @@ module QBIntegration
           income_account_id: account ? account.id : nil
         }
 
-        find_by_sku(name) || create(params)
+        find_by_name(name) || find_by_sku(name) || create(params)
       end
     end
   end

--- a/lib/qb_integration/services/item.rb
+++ b/lib/qb_integration/services/item.rb
@@ -37,7 +37,7 @@ module QBIntegration
           income_account_id: account ? account.id : nil
         }
 
-        find_by_name(name) || find_by_sku(name) || create(params)
+        find_by_sku(name) || find_by_name(name) || create(params)
       end
     end
   end


### PR DESCRIPTION
This is untested, as I had trouble running the tests.

Quickbooks has added in a separate attribute on products and services called SKU. So now name is to be used as the actual name "Spree T-Shirt" and sku is to be used as the sku "ST-001".

This looks up by both to support both old/new users.